### PR TITLE
Remove outline: none

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -8,7 +8,6 @@ body {
 
 a,
 button {
-  outline: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
http://www.outlinenone.com/

> What does the outline property do?
> 
> It provides visual feedback for links that have "focus" when navigating a web document using the TAB key (or equivalent). This is especially useful for folks who can't use a mouse or have a visual impairment. If you remove the outline you are making your site inaccessible for these people.
> 
> Defining focus to navigation elements is an accessibility requirement, it's clearly stated in the Web Content Accessibility Guidelines:
> 
> 2.4.7 Focus Visible: Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible. (Level AA)
> 