### PR TITLE
Adjust documentation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,25 +421,27 @@
       </ul>
     </nav>
     <div class="main-pane">
-      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-      <pre><code>pre {
-  display: block;
-  margin-top: 1em;
-}
+      <div class="markdown">
+        <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+        <pre><code>pre {
+    display: block;
+    margin-top: 1em;
+  }
 
-code {
-  background: var(--lighter-grey);
-  border-radius: var(--theme-border-radius);
-  padding: 0.5em;
-  font-size: 0.8em;
-  font-family: 'Courier New';
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-}</code></pre>
+  code {
+    background: var(--lighter-grey);
+    border-radius: var(--theme-border-radius);
+    padding: 0.5em;
+    font-size: 0.8em;
+    font-family: 'Courier New';
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+  }</code></pre>
+      </div>
     </div>
   </div>
 

--- a/src/css/documentation.css
+++ b/src/css/documentation.css
@@ -4,8 +4,8 @@
 
 .side-pane {
   background: var(--theme-background-grey);
-  padding: 1em;
-  flex: 0 0 250px;
+  padding: 2em;
+  flex: 0 0 25%;
   border-right: 1px solid var(--theme-border-lighter);
 }
 
@@ -13,6 +13,9 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+  width: 100%;
+  max-width: 400px;
+  float: right;
 }
 
 .side-pane__title {
@@ -102,7 +105,7 @@
 }
 
 .main-pane {
-  padding: 3em;
+  padding: 3em 5em;
   background: var(--white);
   flex: 1;
 }
@@ -120,5 +123,15 @@
     border-right: none;
     border-bottom: 1px solid var(--theme-border-lighter);
     flex: auto;
+  }
+}
+
+@media (--larger-than-desktop) {
+  .main-pane .markdown {
+    width: 80%;
+  }
+
+  .side-pane {
+    flex: 0 0 350px;
   }
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -16,6 +16,7 @@
 @import "panel.css";
 @import "sections.css";
 @import "form.css";
+@import "markdown.css";
 @import "documentation.css";
 @import "article.css";
 

--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -1,0 +1,42 @@
+.markdown img {
+  /* Prevent larger images to break layout */
+  max-width: 100%;
+  /* Center images smaller than width */
+  margin: auto;
+  display: block;
+
+}
+
+/* Allow images legends with the following syntax:
+  ![](path_to_image)
+  *image_caption* */
+.markdown img + em {
+  display: block;
+  text-align: center;
+  margin: 0.3em 0.1em;
+}
+
+/* Disable lists default indentation */
+.markdown ol, 
+.markdown ul {
+  margin: 0;
+  padding: 0 0 0 1em;
+}
+
+.markdown li {
+  padding-left: 0.5em;
+}
+
+/* Lighter inline code element */
+code {
+  padding: 0 0.1em;
+  border-radius: 0.2em;
+}
+
+/* But <pre> block should be spaced */
+pre {
+  padding: 0.5em;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+  background-color: #ebeff3;
+}

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -31,7 +31,6 @@ h4 {
 }
 
 p {
-  max-width: 35em; /* best for a 80 characters per line */
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
Documentation didn't render properly so a few adjustments have been made.
- Made the side pane and content width proportional
- Added the markdown specific style from doc.data.gouv.fr

![image](https://user-images.githubusercontent.com/1301085/35926560-bbcb28b4-0c28-11e8-8432-b31f8b14047b.png)
