### PR TITLE
Add full width notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,12 +477,16 @@ code {
     </div>
   </section>
 
+  <div class="notification full-width">Ceci est une note de service.</div>
+  <div class="notification warning full-width closable">Ceci est une note de service <em>fermable</em>.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
+
+
   <section class="notifications">
     <div class="container">
-      <div class="notification">The princess is in another castle.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
-      <div class="notification success">Mission complete!<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
-      <div class="notification warning">All you base are belong to us.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
-      <div class="notification error">Game over.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
+      <div class="notification closable">The princess is in another castle.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
+      <div class="notification success closable">Mission complete!<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
+      <div class="notification warning closable">All you base are belong to us.<button class="close" aria-label="Fermer"><svg class="icon icon-cross"><use xlink:href="#icon-cross"></use></svg></button></div>
+      <div class="notification error">Game over.<button class="close" aria-label="Fermer"></button></div>
     </div>
   </section>
 

--- a/src/css/notifications.css
+++ b/src/css/notifications.css
@@ -8,24 +8,6 @@
   position: relative;
 }
 
-.notification.success {
-  color: var(--theme-success-border);
-  background: var(--theme-success-bg);
-  border: 1px solid var(--theme-success-border);
-}
-
-.notification.warning {
-  color: var(--theme-warning-border);
-  background: var(--theme-warning-bg);
-  border: 1px solid var(--theme-warning-border);
-}
-
-.notification.error {
-  color: var(--theme-error-border);
-  background: var(--theme-error-bg);
-  border: 1px solid var(--theme-error-border);
-}
-
 .notification .close {
   border: 0;
   background: 0;
@@ -38,4 +20,38 @@
   fill: currentColor;
   width: 20px;
   height: 20px;
+}
+
+.notification.closable {
+  padding-right: 3em;
+}
+
+.notification.full-width {
+  width: 100%;
+  margin-bottom: 0;
+  text-align: center;
+  border: 0;
+  box-sizing: border-box;
+}
+
+.notification.full-width.closable .close {
+  right: unset;
+}
+
+.notification.success {
+  color: var(--theme-success-border);
+  background: var(--theme-success-bg);
+  border-color: var(--theme-success-border);
+}
+
+.notification.warning {
+  color: var(--theme-warning-border);
+  background: var(--theme-warning-bg);
+  border-color: var(--theme-warning-border);
+}
+
+.notification.error {
+  color: var(--theme-error-border);
+  background: var(--theme-error-bg);
+  border-color: var(--theme-error-border);
 }


### PR DESCRIPTION
Added an unboxed notification taking the full width of its container. Aimed for more general notifications.
![image](https://user-images.githubusercontent.com/1301085/35983548-84177434-0cf2-11e8-9a65-67b989bd0eef.png)

Also added a class for closable notifications that adds a padding as the close button was passing over text.

Will be used on entreprise.data.gouv.fr:
![image](https://user-images.githubusercontent.com/1301085/35983680-cd4873e2-0cf2-11e8-8d78-0dc9c138fcdc.png)
