### PR TITLE
Vertically align row items to the top, instead of the center

### DIFF
--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
 }
 


### PR DESCRIPTION
Dans un `row`, aligner verticalement les éléments "en haut" et pas "au milieu"

Avant :

![screen shot 2018-03-21 at 22 41 06](https://user-images.githubusercontent.com/1333173/37738968-fb8a77f6-2d58-11e8-91ec-5bdfea3bb5f4.png)

Après :

![screen shot 2018-03-21 at 22 41 13](https://user-images.githubusercontent.com/1333173/37738965-fa202514-2d58-11e8-9db1-03795d9af1e8.png)


