### PR TITLE
Remove transition on hover in nav links

### DIFF
--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -58,7 +58,6 @@
 .nav__links a:hover,
 .nav__links .dropdown:hover {
   background: var(--light-grey);
-  transition: background ease-out 0.5s;
 }
 
 .nav__links a.active {


### PR DESCRIPTION
Je trouve que ça donne un sentiment de lag cette transition (on attend une fraction de seconde pour avoir confirmation de la prise en compte du déplacement de souris), et que ça n'apporte pas grand chose.