### PR TITLE
Change the nav link hover color to lighter grey

### DIFF
--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -57,8 +57,7 @@
 
 .nav__links a:hover,
 .nav__links .dropdown:hover {
-  background: var(--light-grey);
-  transition: background ease-out 0.5s;
+  background: var(--lighter-grey);
 }
 
 .nav__links a.active {


### PR DESCRIPTION
2 raisons :
- le gris plus clair est moins "triste" (AMHA)
- on a un plus fort contraste entre la couleur de fond et la couleur du texte