### PR TITLE
Remove the Firerfox focus rings

### DIFF
--- a/src/css/button.css
+++ b/src/css/button.css
@@ -32,3 +32,7 @@ button.button:active {
   border-bottom: 0;
   margin-bottom: 2px;
 }
+
+button::-moz-focus-inner {
+  border: 0;
+}

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -117,6 +117,11 @@ select:focus {
   outline: none;
 }
 
+select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 label,
 legend {
   display: block;


### PR DESCRIPTION
Suppression des bordures pointillées qui apparaissent sur les `select` et les `button` au focus