### PR TITLE
Remove transitions in the side menus

### DIFF
--- a/src/css/documentation.css
+++ b/src/css/documentation.css
@@ -43,14 +43,12 @@
 
 .side-pane li.side-pane__dropdown .side-pane__link {
   background: url("images/icons/arrow-right.svg") no-repeat;
-  transition: background ease-out 0.5s;
   background-position: center right 1em;
   background-size: 15px 15px;
 }
 
 .side-pane li.side-pane__dropdown:hover .side-pane__link {
   background: var(--light-grey) url("images/icons/arrow-right.svg") no-repeat;
-  transition: background ease-out 0.5s;
   background-position: center right 1em;
   background-size: 15px 15px;
 }
@@ -91,7 +89,6 @@
 .side-pane__submenu .side-pane__sublink:hover {
   color: var(--theme-dark-text);
   background: var(--light-grey);
-  transition: background ease-out 0.5s;
 }
 
 .side-pane__submenu li.active {


### PR DESCRIPTION
- Comme pour #39, je trouve que c'est trop lent, qu'on attend, que ça lag
- Ça permet d'unifier le comportement au hover de tous les éléments du `side-pane` : les éléments de niveau 0 n'ont pas de transition au hover, par contre ceux de niveau 1 (qui font parti du `submenu`) en ont une, ce qui est bizarre à mes yeux