### PR TITLE
fix rawgit url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Commenter les parties qui ne vous sont pas utiles dans `src/css/index.css` puis 
 
 ## Utiliser la dernière version complète
 
-En utilisant rawgit `<link href="https://rawgit.com/etalab/template.data.gouv.fr/master/template.css" rel="stylesheet">`
+En utilisant rawgit `<link href="https://cdn.rawgit.com/etalab/template.data.gouv.fr/master/src/main.css" rel="stylesheet">`


### PR DESCRIPTION
L'url actuelle ne fonctionne pas chez moi, mais celle-ci à l'air ok;

A priori la version sur npm n'est pas à jour ? https://unpkg.com/template.data.gouv.fr@1.0.1/dist/style/main.css