### PR TITLE
Fix icons copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist-site": "copyfiles CNAME images/* images/**/* fonts/**/* index.html dist",
     "dist-css": "postcss --output dist/template.css src/css/template.css",
     "prepublish-css": "postcss --output dist/style/main.css src/css/index.css && NODE_ENV=production postcss --output dist/style/main.min.css src/css/index.css",
-    "prepublish": "rm -rf dist && yarn prepublish-css && copyfiles images/* images/icons/* images/favicons/* fonts/**/* dist"
+    "prepublish": "rm -rf dist && yarn prepublish-css && copyfiles images/* images/icons/**/* images/favicons/* fonts/**/* dist"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Since I moved icons from their original directory, npm script wasn't copying them anymore.
Changed the script to take the new directory into account.

Fixes #63 