### PR TITLE
Stop building twice on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "stylelint-config-standard": "^17.0.0"
   },
   "scripts": {
-    "deploy": "yarn dist && gh-pages -d dist -m 'Deploy [skip ci]'",
+    "deploy": "gh-pages -d dist -m 'Deploy [skip ci]'",
     "dev": "postcss --output dist/template.css --watch src/css/template.css",
     "lint": "stylelint --fix src/css/*.css",
     "test": "stylelint src/css/*.css",


### PR DESCRIPTION
`yarn dist` builds and `yarn deploy` deploys.

The build output is generated in the `build` CI task, saved to workspace, and deployed using `yarn deploy` in the `deploy` CI task.

If deploying from your local machine, you will need to run both commands though. Though the deployment seems automated by Circle CI. :)