### PR TITLE
Fix the mismatch between hexa color codes and actual colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Medium</div>
-                #0053B3
+                #0053b3
               </div>
             </div>
             <div class="color-panel__block">
@@ -191,7 +191,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">White</div>
-                #FFFFFF
+                #ffffff
               </div>
             </div>
             <div class="color-panel__block">
@@ -199,7 +199,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Lighter grey</div>
-                #EBEFF3
+                #ebeff3
               </div>
             </div>
             <div class="color-panel__block">
@@ -207,7 +207,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Light grey</div>
-                #C9D3DF
+                #c9d3df
               </div>
             </div>
             <div class="color-panel__block">
@@ -215,7 +215,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Grey</div>
-                #ADB9C9
+                #adb9c9
               </div>
             </div>
             <div class="color-panel__block">
@@ -223,7 +223,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Dark grey</div>
-                #8393A7
+                #8393a7
               </div>
             </div>
             <div class="color-panel__block">
@@ -231,7 +231,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Darker grey</div>
-                #53657D
+                #53657d
               </div>
             </div>
             <div class="color-panel__block">
@@ -239,7 +239,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Almost black</div>
-                #26353F
+                #26353f
               </div>
             </div>
             <div class="color-panel__block">
@@ -247,7 +247,7 @@
               </div>
               <div class="color-panel__description">
                 <div class="color-panel__name">Black</div>
-                #1C1C1C
+                #1c1c1c
               </div>
             </div>
           </div>
@@ -263,11 +263,11 @@
               <div class="color-panel__description-double">
                 <div class="color-panel__description">
                   <div class="color-panel__name">Green</div>
-                  #03BD5B
+                  #03bd5b
                 </div>
                 <div class="color-panel__description">
                   <div class="color-panel__name">Light green</div>
-                  #DAF5E7
+                  #daf5e7
                 </div>
               </div>
             </div>
@@ -281,11 +281,11 @@
               <div class="color-panel__description-double">
                 <div class="color-panel__description">
                   <div class="color-panel__name">Orange</div>
-                  #FF9947
+                  #ff9947
                 </div>
                 <div class="color-panel__description">
                   <div class="color-panel__name">Light orange</div>
-                  #FFF0E4
+                  #fff0e4
                 </div>
               </div>
             </div>
@@ -317,11 +317,11 @@
               <div class="color-panel__description-double">
                 <div class="color-panel__description">
                   <div class="color-panel__name">Blue</div>
-                  #03BD5B
+                  #0053b3
                 </div>
                 <div class="color-panel__description">
                   <div class="color-panel__name">Lighter blue</div>
-                  #DAF5E7
+                  #b4e1fa
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This pull request fixes a small typo where some hexa colors codes (starting with `#`) displayed on the page wouldn't match the actual color attached to them. Also, the pull request removes caps from hexa codes to improve readability.

<img width="1440" alt="mismatch" src="https://user-images.githubusercontent.com/3286488/46948310-e9650000-d07d-11e8-99fd-719d8294274a.png">