### PR TITLE
fix links in footer

### DIFF
--- a/src/css/layouts/footer.css
+++ b/src/css/layouts/footer.css
@@ -4,6 +4,10 @@
   padding: var(--space-l) 0;
 }
 
+.footer a:hover {
+  background: 0;
+}
+
 .footer .container {
   display: flex;
   flex-flow: row wrap;
@@ -43,6 +47,10 @@
 .footer__links a {
   color: var(--white);
   text-decoration: none;
+}
+
+.footer__links a:hover {
+  background: var(--darker-grey);
 }
 
 .footer__logo {

--- a/src/css/layouts/section.css
+++ b/src/css/layouts/section.css
@@ -38,6 +38,7 @@
 .section-dark a,
 .section-color a {
   color: currentColor;
+  background: var(--darker-grey);
 }
 
 .section__title + .row,


### PR DESCRIPTION
Links on hover with a dark background were unreadable because of light background change.
Changed to a darker color for better readability.

Fix #91 