### PR TITLE
add a polyfill for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added a `required` class to `labels` to inform about _required_ fields
 
+#### Bug fixes
+- Added a polyfill for Internet Explorer support
+
 ## v1.2.0 (23/01/2019)
 
 #### Enhancements

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
   <title>Tagline libérer les données sans effort et sur data.gouv.fr - template.data.gouv.fr</title>
 
   <link rel="stylesheet" href="template.css">
-
+  <script type="text/javascript">
+    if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
+      document.write('<script src="https://unpkg.com/@babel/polyfill@7.0.0/dist/polyfill.js"><\/script>');
+      document.write('<script src="https://unpkg.com/url-polyfill@1.0.14/url-polyfill.js"><\/script>');
+    }
+  </script>
   <!-- Search Engine -->
   <meta name="description" content="Tagline libérer les données sans effort et sur data.gouv.fr">
   <meta name="image" content="https://etalab.github.io/template.data.gouv.fr/images/preview.png">


### PR DESCRIPTION
As suggested in #70, there's now a link to a polyfill for Internet Explorer that doesn't handle grids.