### PR TITLE
add style for required input labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.1
+
+#### Enhancements
+
+- Added a `required` class to `labels` to inform about _required_ fields
+
 ## v1.2.0 (23/01/2019)
 
 #### Enhancements

--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
           </div>
 
           <div class="form__group">
-            <label for="textarea">Renseignez votre meilleure recette de lasagnes :</label>
+            <label class="required" for="textarea">Renseignez votre meilleure recette de lasagnes :</label>
             <textarea name="textarea" id="textarea"></textarea>
           </div>
 

--- a/src/css/elements/input.css
+++ b/src/css/elements/input.css
@@ -115,3 +115,10 @@ select:-moz-focusring {
   color: transparent;
   text-shadow: 0 0 0 #000;
 }
+
+label.required::after {
+  content: '✱';
+  color: var(--red);
+  font-weight: 700;
+  margin-left: var(--space-xs);
+}


### PR DESCRIPTION
Labels can have a `required` class that adds a red ✽ next to them.
Fix #96  