### PR TITLE
set margin to panels by default

### DIFF
--- a/src/css/components/panel.css
+++ b/src/css/components/panel.css
@@ -7,6 +7,10 @@
   border: 1px solid var(--theme-border-lighter);
 }
 
+.panel + * {
+  margin-top: var(--space-m);
+}
+
 .panel > :last-child {
   margin-bottom: 0;
 }

--- a/src/css/template.css
+++ b/src/css/template.css
@@ -21,10 +21,6 @@
   display: block;
 }
 
-.panel + * {
-  margin-top: var(--space-m);
-}
-
 .color-panel {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/src/css/utility/layout.css
+++ b/src/css/utility/layout.css
@@ -13,6 +13,7 @@
 
 .row > * + * {
   margin-left: var(--space-m);
+  margin-top: 0;
 }
 
 @media (--smaller-than-tablet) {


### PR DESCRIPTION
According to feedbacks, panels should be separated by margins when they follow each other.
This should give all following panels margins according to the layout they're in.