### PR TITLE
inputs enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.2.2
+
+#### Enhancements
+
+- Added a new color to buttons
+- `input[type="submit"]` now has the same default width and a pointer on hover
+- Checkboxes and radio buttons options now have a larger margins between them
+- Selects on Firefox are the same height as other inputs
+- Required marker is now set on the left of labels for better scanning
+
 ## v1.2.1 (20/03/2019)
 
 #### Features

--- a/src/css/elements/button.css
+++ b/src/css/elements/button.css
@@ -26,6 +26,8 @@ input[type="button"]:visited {
   top: 0;
   overflow: hidden;
   text-decoration: none;
+  cursor: pointer;
+  width: auto;
 }
 
 a.button:hover,

--- a/src/css/elements/input.css
+++ b/src/css/elements/input.css
@@ -123,9 +123,12 @@ select:-moz-focusring {
   text-shadow: 0 0 0 #000;
 }
 
-label.required::after {
+label.required::before {
   content: '✱';
   color: var(--red);
   font-weight: 700;
-  margin-left: var(--space-xs);
+  padding-right: var(--space-xs);
+  position: absolute;
+  left: 0;
+  transform: translateX(-100%);
 }

--- a/src/css/elements/input.css
+++ b/src/css/elements/input.css
@@ -107,6 +107,13 @@ select {
   width: auto;
 }
 
+@-moz-document url-prefix() {
+  select {
+    padding-top: 0.438em;
+    padding-bottom: 0.438em;
+  }
+}
+
 select:focus {
   outline: none;
 }


### PR DESCRIPTION
- Added a new color to buttons
- `input[type="submit"]` now has the same default width and a pointer on hover
- Checkboxes and radio buttons options now have a larger margins between them
- Selects on Firefox are the same height as other inputs
- Required marker is now set on the left of labels for better scanning