### PR TITLE
improve buttons for responsive

### DIFF
--- a/src/css/components/form.css
+++ b/src/css/components/form.css
@@ -81,3 +81,14 @@ fieldset {
   flex-shrink: 0;
   margin-left: var(--space-s);
 }
+
+@media (--smaller-than-mobile) {
+  .input__group {
+    flex-direction: column;
+  }
+
+  .input__group .button {
+    margin-left: 0;
+    margin-top: var(--space-s);
+  }
+}

--- a/src/css/elements/button.css
+++ b/src/css/elements/button.css
@@ -167,3 +167,18 @@ a.button.secondary {
 .button-outline + .button-outline {
   margin-left: 1em;
 }
+
+@media (--smaller-than-mobile) {
+  a.button,
+  button.button,
+  input[type="submit"],
+  input[type="button"] {
+    width: 100%;
+  }
+
+  .button + .button,
+  .button-outline + .button-outline {
+    margin-top: 1em;
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
Make buttons take full width on mobile and add a margin on top of following buttons.

![image](https://user-images.githubusercontent.com/1301085/59288351-e3a6d500-8c73-11e9-818d-3eedc82babcc.png)
