### PR TITLE
Fix the color of a button when it has the :focus.

### DIFF
--- a/src/css/elements/button.css
+++ b/src/css/elements/button.css
@@ -85,7 +85,8 @@ a.button-outline.primary {
 }
 
 .button-outline.primary:hover,
-.button-outline.primary:active {
+.button-outline.primary:active,
+.button-outline.primary:focus {
   border-color: var(--dark-blue);
   color: var(--dark-blue);
 }
@@ -97,7 +98,8 @@ a.button-outline.warning {
 }
 
 .button-outline.warning:hover,
-.button-outline.warning:active {
+.button-outline.warning:active,
+.button-outline.warning:focus {
   border-color: var(--dark-red);
   color: var(--dark-red);
 }
@@ -109,7 +111,8 @@ a.button-outline.secondary {
 }
 
 .button-outline.secondary:hover,
-.button-outline.secondary:active {
+.button-outline.secondary:active,
+.button-outline.secondary:focus {
   border-color: var(--darkest-grey);
   color: var(--theme-dark-text);
 }
@@ -139,7 +142,8 @@ a.button.warning {
 }
 
 .button.warning:hover,
-.button.warning:active {
+.button.warning:active,
+.button.warning:focus {
   background-color: var(--dark-red);
 }
 
@@ -149,7 +153,8 @@ a.button.warning-light {
 }
 
 .button.warning-light:hover,
-.button.warning-light:active {
+.button.warning-light:active,
+.button.warning-light:focus {
   background-color: var(--dark-orange);
 }
 
@@ -159,7 +164,8 @@ a.button.secondary {
 }
 
 .button.secondary:hover,
-.button.secondary:active {
+.button.secondary:active,
+.button.secondary:focus {
   background-color: var(--darkest-grey);
 }
 


### PR DESCRIPTION
When a button has the focus it was dark-blue or white for button-outlined. 
This PR fixes this and keep the button in dark-red for warning, ...