### PR TITLE
fix input inlining on chrome

### DIFF
--- a/src/css/components/form.css
+++ b/src/css/components/form.css
@@ -38,8 +38,6 @@ fieldset {
   margin: 0;
   padding: 0;
   width: 100%;
-  display: flex;
-  align-items: center;
 }
 
 .overlay-button {

--- a/src/css/elements/input.css
+++ b/src/css/elements/input.css
@@ -46,8 +46,8 @@ input[type=radio]::before {
   border-color: var(--theme-primary);
   border-radius: 50%;
   position: absolute;
-  top: 0.35em;
-  left: 0.3em;
+  top: 0.3em;
+  left: 0.35em;
   width: 0.5em;
   height: 0.5em;
   transform: scale(0);

--- a/src/css/elements/switch.css
+++ b/src/css/elements/switch.css
@@ -6,7 +6,7 @@ input[type="checkbox"].switch {
 input[type="checkbox"].switch::before {
   transform: none;
   transition: all ease-out 250ms;
-  top: 0.1em;
+  top: 0.15em;
   background: var(--blue);
   border-radius: 1em;
 }
@@ -30,7 +30,7 @@ input[type="checkbox"].switch:disabled::before {
 label.switch-text {
   display: inline-block;
   position: relative;
-  padding: 0 0.5em;
+  padding: 0 0.75em;
 }
 
 label.switch-text input[type="checkbox"].switch {
@@ -47,11 +47,12 @@ label.switch-text input[type="checkbox"].switch:checked {
 
 label.switch-text input[type="checkbox"].switch::before {
   width: 50%;
-  height: 1.3em;
+  height: 1.15em;
+  left: 0.2em;
 }
 
 label.switch-text input[type="checkbox"].switch:checked::before {
-  left: calc(50% - 0.1em);
+  left: calc(50% - 0.2em);
 }
 
 label.switch-text .switch-option {


### PR DESCRIPTION
For some reason flexbox doesn't work on the fieldset on chrome anymore so it has been removed.
I also realigned the inputs while at it.

![image](https://user-images.githubusercontent.com/1301085/64185559-a9616400-ce6d-11e9-8d6e-2c287c795c4e.png)
