### PR TITLE
Remove button margin

### DIFF
--- a/src/css/elements/button.css
+++ b/src/css/elements/button.css
@@ -28,7 +28,6 @@ input[type="button"]:visited {
   text-decoration: none;
   cursor: pointer;
   width: auto;
-  margin: 1em 1em 0 0;
 }
 
 a.button:hover,


### PR DESCRIPTION
The default button margin causes alignment errors, especially with inputs. 

## Examples
<img width="400" alt="Capture d’écran 2019-09-26 à 17 33 09" src="https://user-images.githubusercontent.com/7040549/65702978-3ae67f00-e084-11e9-8e39-45308096970c.png">
<img width="400" alt="Capture d’écran 2019-09-26 à 17 32 52" src="https://user-images.githubusercontent.com/7040549/65702979-3b7f1580-e084-11e9-984b-15907e083cfa.png">

It is better to leave the buttons without margin by default and let users manage this setting in their integrations.