### PR TITLE
Use most supported flex-end for justify-content in pagination

### DIFF
--- a/src/css/components/pagination.css
+++ b/src/css/components/pagination.css
@@ -2,7 +2,7 @@
 .pagination {
   display: flex;
   flex-direction: row;
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
   flex-wrap: wrap;
   margin-top: var(--space-m);
@@ -33,7 +33,7 @@ select.pagination__display {
   padding: 0;
   overflow: hidden;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   margin-left: var(--space-m);
 }
 


### PR DESCRIPTION
 I got warning from a linter with the current `end` value.
This should render the same thing.

cf:
https://caniuse.com/#search=justify-content
