### PR TITLE
Màj lien vers le nouveau template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-🚧 Ce dépôt n’est plus maintenu et sera à terme remplacé par une nouvelle version dont le développement est en cours. 🚧
+🚧 Ce dépôt n’est plus maintenu et a été remplacé par [template.incubateur.net](http://template.incubateur.net) 🚧
 
 
 # template.data.gouv.fr [![CircleCI](https://circleci.com/gh/etalab/template.data.gouv.fr.svg?style=svg)](https://circleci.com/gh/etalab/template.data.gouv.fr)

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
     <div class="hero__container">
       <h1>Titre - chili con carne</h1>
       <p>Tagline - libérer les données sans effort et sur data.gouv.fr</p>
+      <p>🚧 Ce site n’est plus maintenu et a été remplacé par <a href="http://template.incubateur.net">template.incubateur.net"</a> 🚧</p>
       <p>Code source : <a target="new" href="https://github.com/etalab/template.data.gouv.fr">github.com/etalab/template.data.gouv.fr</a></p>
     </div>
   </div>


### PR DESCRIPTION
Le nouveau site, http://template.incubateur.net reprend le principe de ce repo mais utilise le Design système de l'état.